### PR TITLE
Fix: dev css modules classnames should include filename

### DIFF
--- a/docusaurus-plugin-sass.js
+++ b/docusaurus-plugin-sass.js
@@ -15,7 +15,7 @@ module.exports = function(_, {id, ...options}) {
                   modules: {
                     localIdentName: isProd
                       ? `[local]_[hash:base64:4]`
-                      : `[local]_[path]`,
+                      : `[local]_[path][name]`,
                     exportOnlyLocals: isServer,
                   },
                   importLoaders: 2,


### PR DESCRIPTION
Add the css module filename to avoid potential dev classname collisions.

See:
https://github.com/facebook/docusaurus/pull/5034

Docusaurus just merged this behaviour in master.
I think this plugin should follow the same behaviour.

Also, I personally encounter classname collisions in development.